### PR TITLE
feat: add logs rotation for service backend

### DIFF
--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -14,3 +14,8 @@ services:
       -  ../envs/common-blockscout.env
     volumes:
       - ./logs/:/app/logs/
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -33,3 +33,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/docker-compose/services/frontend.yml
+++ b/docker-compose/services/frontend.yml
@@ -10,3 +10,8 @@ services:
     container_name: 'frontend'
     env_file:
       -  ../envs/common-frontend.env
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/docker-compose/services/nginx.yml
+++ b/docker-compose/services/nginx.yml
@@ -18,3 +18,8 @@ services:
       - 8080:8080
       - 8081:8081
       - 443:443
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/docker-compose/services/redis.yml
+++ b/docker-compose/services/redis.yml
@@ -7,3 +7,8 @@ services:
     command: redis-server
     volumes:
       - ./redis-data:/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -32,6 +32,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   stats:
     image: ghcr.io/blockscout/stats:${STATS_DOCKER_TAG:-latest}
@@ -48,3 +53,8 @@ services:
       - STATS__BLOCKSCOUT_DB_URL=${STATS__BLOCKSCOUT_DB_URL:-postgresql://blockscout:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout}
       - STATS__CREATE_DATABASE=true
       - STATS__RUN_MIGRATIONS=true
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"


### PR DESCRIPTION
Make changes to the backend service located in docker-compose/services/backend.yml to provide logs rotation